### PR TITLE
added documentation for successful installing apiai in a clean fresh python environment

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,12 +53,15 @@ or install it from repo:
 
     $ pip install https://github.com/api-ai/api-ai-python.git
     
-You might run into problems because some dependencies in your python environment are missing. You need to install numpy (which is available in alomost all package managers) and `scipy<http://www.scipy.org/install.html>`_. 
+You might run into problems because some dependencies in your python environment are missing. You need to install numpy (which is available in alomost all package managers) and `scipy <http://www.scipy.org/install.html>`_. 
 
-In ubunutu the following will do the job
+In ubunutu the following will do the job:
+
 .. code-block:: bash
+
     $ apt-get install python-numpy python-scipy python-matplotlib ipython ipython-notebook python-pandas python-sympy python-nose python-pip
     $ pip install apiai
+
 Documentation
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -53,13 +53,13 @@ or install it from repo:
 
     $ pip install https://github.com/api-ai/api-ai-python.git
     
-You might run into problems because some dependencies in your python environment are missing. You need to install numpy (which is available in alomost all package managers) and `scipy <http://www.scipy.org/install.html>`_. 
+You might run into problems because some dependencies in your python environment are missing. You need to install numpy (which is available in alomost all package managers) and `scipy <http://www.scipy.org/install.html>`_. For running the examples you also need python audio.
 
 In ubunutu the following will do the job:
 
 .. code-block:: bash
 
-    $ apt-get install python-numpy python-scipy python-matplotlib ipython ipython-notebook python-pandas python-sympy python-nose python-pip
+    $ apt-get install python-pyaudio python-numpy python-scipy python-matplotlib ipython ipython-notebook python-pandas python-sympy python-nose python-pip
     $ pip install apiai
 
 Documentation

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,13 @@ or install it from repo:
 .. code-block:: bash
 
     $ pip install https://github.com/api-ai/api-ai-python.git
+    
+You might run into problems because some dependencies in your python environment are missing. You need to install numpy (which is available in alomost all package managers) and `scipy<http://www.scipy.org/install.html>`_. 
 
+In ubunutu the following will do the job
+.. code-block:: bash
+    $ apt-get install python-numpy python-scipy python-matplotlib ipython ipython-notebook python-pandas python-sympy python-nose python-pip
+    $ pip install apiai
 Documentation
 -------------
 


### PR DESCRIPTION
I could not install apiai without installing python dependencies that you did not mention in your documentation. it was easy enough to read the error messages for an experienced user but I guess most people will benefit from mentioning the depencies in the readme right away