### PR TITLE
Don't attempt to serialize a map object.

### DIFF
--- a/apiai/requests/user_entities/user_entities_request.py
+++ b/apiai/requests/user_entities/user_entities_request.py
@@ -90,4 +90,4 @@ class UserEntitiesRequest(Request):
         return None
 
     def _prepage_end_request_data(self):
-        return json.dumps(map(lambda x: x._to_dict(), self._user_entities))
+        return json.dumps(list(map(lambda x: x._to_dict(), self._user_entities)))


### PR DESCRIPTION
map() returns a  map object, which json can't serialize.
Convert to a list before serialization.